### PR TITLE
Package linux artifacts into .deb files

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -128,6 +128,20 @@ jobs:
       run: ./dist/roboto-${{ matrix.os }}-${{ matrix.arch }} --version --suppress-upgrade-check
     - name: Exercise roboto-agent
       run: ./dist/roboto-agent-${{ matrix.os }}-${{ matrix.arch }} --help
+    - name: Package .deb (linux only)
+      if: matrix.os == 'linux'
+      run: |
+        VERSION="$(./dist/roboto-${{ matrix.os }}-${{ matrix.arch }} --version --suppress-upgrade-check)"
+        mkdir -p roboto_deb/DEBIAN
+        echo "Package: roboto" > roboto_deb/DEBIAN/control
+        echo "Version: ${VERSION}" >> roboto_deb/DEBIAN/control
+        echo "Architecture: arm64" >> roboto_deb/DEBIAN/control
+        echo "Maintainer: Roboto AI <support@roboto.ai>" >> roboto_deb/DEBIAN/control
+        echo "Description: Roboto CLI and Agent" >> roboto_deb/DEBIAN/control
+        mkdir -p roboto_deb/usr/bin
+        cp ./dist/roboto-linux-${{ matrix.arch }} roboto_deb/usr/bin/roboto
+        cp ./dist/roboto-agent-linux-${{ matrix.arch }} roboto_deb/usr/bin/roboto-agent
+        dpkg-deb --build roboto_deb dist/roboto-linux-${{ matrix.arch }}.deb
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }}-${{ matrix.arch }}-artifacts

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -104,7 +104,7 @@ jobs:
             image: ubuntu-20.04
             arch: x86_64
           - os: linux
-            image: ubuntu-20.04
+            image: ubuntu-24.04-arm64
             arch: aarch64
           - os: windows
             image: windows-latest
@@ -141,7 +141,7 @@ jobs:
         mkdir -p roboto_deb/usr/bin
         cp ./dist/roboto-linux-${{ matrix.arch }} roboto_deb/usr/bin/roboto
         cp ./dist/roboto-agent-linux-${{ matrix.arch }} roboto_deb/usr/bin/roboto-agent
-        dpkg-deb --build roboto_deb dist/roboto-linux-${{ matrix.arch }}.deb
+        dpkg-deb --build roboto_deb dist/roboto-linux-${{ matrix.arch }}_${VERSION}.deb
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }}-${{ matrix.arch }}-artifacts


### PR DESCRIPTION
Problem: A customer requested that we bundle linux assets into .deb files to make them easier to install.

Solution: Extend the GitHub Actions workflow to package a deb for aarch64 and amd64 linux.

Testing: The PR for this commit will run the workflow, which can be used to verify success.