### PR TITLE
Use the release_notes file when creating a release

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -196,4 +196,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/roboto-*
+          body_path: RELEASE_NOTES.md
           make_latest: true


### PR DESCRIPTION
The release action accepts `body_path` which is supposed to use the given file as the body of the release notes message.

https://github.com/softprops/action-gh-release?tab=readme-ov-file#-external-release-notes