### PR TITLE
Use ubuntu 24.04 instead of 20.04

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -21,7 +21,7 @@ jobs:
             image: macos-13
             arch: x86_64
           - os: linux
-            image: ubuntu-20.04
+            image: ubuntu-24.04
             arch: x86_64
           - os: linux
             image: ubuntu-24.04-arm64


### PR DESCRIPTION
20.04 was deprecated in February and removed last week.