### PR TITLE
Fix missing roboto-mcap-codec in packaged binaries

### DIFF
--- a/BUILD.pants
+++ b/BUILD.pants
@@ -3,7 +3,8 @@ python_requirements(
     source="pyproject.toml",
     module_mapping={
         "mcap-ros1-support": ("mcap_ros1",),
-        "mcap-ros2-support": ("mcap_ros2",)
+        "mcap-ros2-support": ("mcap_ros2",),
+        "roboto-mcap-codec": ("mcap_codec",),
     },
 )
 


### PR DESCRIPTION
The roboto-mcap-codec distribution ships its extension as the module `mcap_codec`, not the `roboto_mcap_codec` that Pants guesses from the project name. With no module_mapping override, Pants could not infer the owner of `from mcap_codec import ...` in decoder_factory.py, so the requirement was silently dropped from roboto-cli.pex / roboto-agent-cli.pex. The build still succeeded (un-inferred imports are only a WARN), but the resulting binary crashed at runtime resolving its declared dependency, which broke `roboto --version` in the .deb packaging step of the v0.48.0 release workflow.

Map roboto-mcap-codec -> mcap_codec so Pants infers the dependency and bundles the abi3 wheel into the packaged binaries.